### PR TITLE
CatsMonadAsyncError#async typo fix

### DIFF
--- a/effects/cats/src/main/scala/sttp/client3/impl/cats/CatsMonadAsyncError.scala
+++ b/effects/cats/src/main/scala/sttp/client3/impl/cats/CatsMonadAsyncError.scala
@@ -17,7 +17,7 @@ class CatsMonadAsyncError[F[_]](implicit F: Concurrent[F]) extends MonadAsyncErr
     F.recoverWith(rt)(h)
 
   override def async[T](register: ((Either[Throwable, T]) => Unit) => Canceler): F[T] =
-    F.cancelable(register.andThen(c => F.delay(c.cancel)))
+    F.cancelable(register.andThen(c => F.delay(c.cancel())))
 
   override def eval[T](t: => T): F[T] = F.delay(t)
 


### PR DESCRIPTION
Not sure, but it seems that there is a small typo

Before submitting pull request:
- [ ] Check if the project compiles by running `sbt compile`
- [ ] Verify docs compilation by running `sbt compileDocs`
- [ ] Check if tests pass by running `sbt test`
- [ ] Format code by running `sbt scalafmt`
